### PR TITLE
Fix Layout in Admininstration > Workflows

### DIFF
--- a/app/views/workflow_enhancements/_workflow_graph.html.erb
+++ b/app/views/workflow_enhancements/_workflow_graph.html.erb
@@ -23,7 +23,7 @@
       <% end %>
     </h4>
     <div class="workflowGraph">
-      <svg id="workflow-vis" width="800" height="600">
+      <svg id="workflow-vis">
         <g transform="translate(20,20)"/>
       </svg>
     </div>

--- a/app/views/workflow_enhancements/_workflow_graph.html.erb
+++ b/app/views/workflow_enhancements/_workflow_graph.html.erb
@@ -62,12 +62,12 @@
       .rankDir("LR");
     layout = renderer.layout(layout).run(dagreD3.json.decode(json.nodes, json.edges), d3.select("#workflow-vis g"));
 
-    var gw = layout.graph().width;
-    var gh = layout.graph().height;
-    var w = Math.min($(window).width() * 0.8, gw);
-    var h = Math.min($(window).height() * 0.8, gh);
+    var gw = layout.graph().width + 80;
+    var gh = layout.graph().height + 40;
+    var w = Math.min(((document.getElementsByClassName("workflowGraphContainer").length > 0) ? document.getElementsByClassName("workflowGraph")[0].offsetWidth : $(window).width()), gw);
+    var h = Math.min($(window).height(), gh);
     var s = Math.min(w / gw, h / gh);
-    d3.select("svg").attr("width", w + 40).attr("height", h + 40);
+    d3.select("svg").attr("width", w).attr("height", h);
     if (s < 1) {
       d3.select("svg").attr("transform", "scale(" + s + ")");
     }

--- a/assets/stylesheets/workflow_enhancements.css
+++ b/assets/stylesheets/workflow_enhancements.css
@@ -10,7 +10,7 @@
 .workflowGraph {
   background: white;
   border: 1px solid #E4E4E4;
-  display: inline-block;
+//  display: inline-block;
 }
 
 text {


### PR DESCRIPTION
The graphs and the area to resize the graphs were not fitting inside their boxes in some occasions (mostly when the graph was too wide).

In Redmine, the graph is shown in a window when called from inside an issue, and in a div when called from Administration > Workflow.

This patch fixes the layout so that the graph fits in the box in Administration > Workflows.
