### PR TITLE
feat: added workflows patch to work with redmine 3.4

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -11,6 +11,11 @@ Redmine::Plugin.register :redmine_workflow_enhancements do
   author_url 'https://github.com/dr-itz/'
 
   requires_redmine '2.2.0'
+  if Redmine::VERSION::MAJOR >= 3 && Redmine::VERSION::MINOR >= 4
+    Rails.configuration.to_prepare do 
+      WorkflowsController.send(:include, WorkflowEnhancements::Patches::WorkflowsControllerPatch)
+    end
+  end
 
   project_module :issue_tracking do
     permission :workflow_graph_view, :workflow_enhancements => :show

--- a/lib/workflow_enhancements/patches/workflows_controller_patch.rb
+++ b/lib/workflow_enhancements/patches/workflows_controller_patch.rb
@@ -1,0 +1,32 @@
+module WorkflowEnhancements
+  module Patches
+    module WorkflowsControllerPatch
+      def self.included(base) # :nodoc
+        base.extend(ClassMethods)
+        base.send(:include, InstanceMethods)
+        base.class_eval do
+          unloadable
+          alias_method_chain :find_statuses , :workflow_enhancements
+        end
+      end
+
+      module ClassMethods; end
+
+      module InstanceMethods
+        def find_statuses_with_workflow_enhancements
+          @used_statuses_only = (params[:used_statuses_only] == '0' ? false : true)
+          if @trackers && @used_statuses_only
+            role_ids = Role.all.select(&:consider_workflow?).map(&:id)
+            status_ids = WorkflowTransition.where(
+              :tracker_id => @trackers.map(&:id), :role_id => role_ids
+            ).distinct.pluck(:old_status_id, :new_status_id).flatten.uniq
+            status_ids.concat TrackerStatus.where(:tracker_id => @trackers.map(&:id)).distinct.pluck(:issue_status_id).flatten.uniq
+            status_ids = status_ids.flatten.uniq
+            @statuses = IssueStatus.where(:id => status_ids).sorted.to_a.presence
+          end
+          @statuses ||= IssueStatus.sorted.to_a
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
refs #https://www.redmine.org/issues/24281

### PROBLEM
In Redmine version 3.4 they added a function in the workflows controller to not show irrelevant permissions, but the redmine_workflow_enhancements plugin did not expect the workflow controller to search for the possible situations for a call type when displaying a workflow. With this, Redmine stopped displaying the situations defined in the configuration of the type of call (which are made by the plugin), displaying only the situations that are in the workflow (Redmine's default behavior)
The change can be found at the following link: https://www.redmine.org/issues/24281

### SOLUTION
The solution was to patch the workflows controller by concatenating the situations returned by the workflows_enhancements plugin (which are defined in the call type configuration and have no linked workflow). This patch is only called if the version of Redmine is greater than 3.4 (which was when that function that broke the plugin was added).