### PR TITLE
fixes the tracker patch so tracker config can be saved again #20

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,6 +1,5 @@
 require_dependency 'workflow_enhancements/hooks'
 require_dependency 'workflow_enhancements/patches/action_view_rendering'
-require_dependency 'workflow_enhancements/patches/tracker_patch'
 
 Redmine::Plugin.register :redmine_workflow_enhancements do
   name 'Redmine Workflow Enhancements'
@@ -16,3 +15,8 @@ Redmine::Plugin.register :redmine_workflow_enhancements do
     permission :workflow_graph_view, :workflow_enhancements => :show
   end
 end
+
+Rails.configuration.to_prepare do
+  WorkflowEnhancements::Patches::TrackerPatch.apply
+end
+

--- a/lib/workflow_enhancements/patches/tracker_patch.rb
+++ b/lib/workflow_enhancements/patches/tracker_patch.rb
@@ -1,29 +1,37 @@
-require_dependency 'tracker'
+module WorkflowEnhancements
+  module Patches
+    module TrackerPatch
+      def self.apply
+        unless Tracker < self
+          Tracker.prepend self
+          Tracker.class_eval do
+            safe_attributes :predef_issue_status_ids
+            has_many :tracker_statuses
+            has_many :predef_issue_statuses, :through => :tracker_statuses
+          end
+        end
+      end
 
-class Tracker
-  has_many :tracker_statuses
-  has_many :predef_issue_statuses, :through => :tracker_statuses
+      def issue_statuses
+        if @issue_statuses
+          return @issue_statuses
+        elsif new_record?
+          return []
+        end
 
-  def issue_statuses_with_workflow_enhancements
-    if @issue_statuses
-      return @issue_statuses
-    elsif new_record?
-      return []
-    end
-
-    ids = WorkflowTransition.connection.select_rows(
-      "SELECT DISTINCT old_status_id, new_status_id
+        ids = WorkflowTransition.connection.select_rows(
+          "SELECT DISTINCT old_status_id, new_status_id
        FROM #{WorkflowTransition.table_name}
        WHERE tracker_id = #{id} AND type = 'WorkflowTransition'").flatten
-    ids.concat TrackerStatus.connection.select_rows(
-      "SELECT issue_status_id
+        ids.concat TrackerStatus.connection.select_rows(
+          "SELECT issue_status_id
        FROM #{TrackerStatus.table_name}
        WHERE tracker_id = #{id}")
 
-    ids = ids.flatten.uniq
-    @issue_statuses = IssueStatus.where(:id => ids).all.sort
+        ids = ids.flatten.uniq
+        @issue_statuses = IssueStatus.where(:id => ids).all.sort
+      end
+    end
+
   end
-
-  alias_method_chain :issue_statuses, :workflow_enhancements
 end
-


### PR DESCRIPTION
this fixes issue #20 by adding the predefined tracker ids to Tracker's safe_attributes. Also refactored the patch to use prepend while I was at it.